### PR TITLE
Populate stream field in video object.

### DIFF
--- a/api.go
+++ b/api.go
@@ -304,6 +304,7 @@ func (api *api) unmarshalVideo(r Receiver) (v *Video) {
 	v.AnalyticsCategory = r.AnalyticsCategory
 	v.AdvertisingCategory = r.AdvertisingCategory
 	v.ShowAds = r.ShowAds
+	v.Stream = r.Stream
 	for _, rInner := range r.Media {
 		item, err := api.UnmarshalReceiver(rInner)
 		if err != nil {

--- a/model.go
+++ b/model.go
@@ -222,6 +222,7 @@ type Video struct {
 	AnalyticsCategory   string        `json:"analytics_category"`
 	AdvertisingCategory string        `json:"advertising_category"`
 	ShowAds             bool          `json:"show_ads"`
+	Stream              string        `json:"m3u8"`
 }
 
 func (v *Video) GetType() ItemType {


### PR DESCRIPTION
This is part of OPT-1038. Stream was not being populated for ibVideo objects. This needs to go through before merge request for the htv-server repo can go through.